### PR TITLE
feature/issue-7 dummyCurrencyData : 환율 정보(Dummy Data)를 제공

### DIFF
--- a/currency_rate_chatbot/README.md
+++ b/currency_rate_chatbot/README.md
@@ -13,6 +13,7 @@
 - OpenJDK 1.8.0_222
 - Gradle 5.4.1
 - Lombok 1.18.8
+- H2 1.4.199
 
 ## API
 - [LINE Messaging API](https://developers.line.biz/en/docs/messaging-api/overview/)

--- a/currency_rate_chatbot/currency-rate-bot/build.gradle
+++ b/currency_rate_chatbot/currency-rate-bot/build.gradle
@@ -20,7 +20,9 @@ repositories {
 
 dependencies {
     implementation('com.linecorp.bot:line-bot-spring-boot:2.7.0')
-    compileOnly ('org.projectlombok:lombok')
+    implementation ('org.springframework.boot:spring-boot-starter-data-jpa')
+    implementation ('org.projectlombok:lombok')
+    runtime ('com.h2database:h2:1.4.199')
     annotationProcessor ('org.projectlombok:lombok')
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude module: 'junit'

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/BotService.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/BotService.java
@@ -46,9 +46,10 @@ public class BotService {
         }
 
         if (Currency.isCurrency(userMessage)) {
-            final Optional<UserMessage> latestUserMessage = userMessageRepository.findFirstByUserIdOrderByIdDesc(userId);
+            final UserMessage latestUserMessage = userMessageRepository.findFirstByUserIdOrderByIdDesc(userId).orElse(null);
+            log.info("latestUserMessage: {}", latestUserMessage);
             final StringBuilder stringBuilder = new StringBuilder();
-            if (StringUtils.isEmpty(latestUserMessage) || !Currency.isCurrency(latestUserMessage.get().getMessage())) {
+            if (StringUtils.isEmpty(latestUserMessage) || !Currency.isCurrency(latestUserMessage.getMessage())) {
                 stringBuilder.append("상대 통화 선택하기\n(" + userMessage + " → ???)\n");
                 Arrays.stream(Currency.values())
                         .map(c -> c.name())
@@ -58,7 +59,7 @@ public class BotService {
                 return Collections.singletonList(textMessage);
             }
 
-            final Currency baseCurrency = Currency.valueOf(latestUserMessage.get().getMessage());
+            final Currency baseCurrency = Currency.valueOf(latestUserMessage.getMessage());
             final Currency counterCurrency = Currency.valueOf(userMessage);
 
             stringBuilder.append(baseCurrency.name() + "/" + counterCurrency.name() + "의 환율 : ");

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/BotService.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/BotService.java
@@ -2,74 +2,30 @@ package me.isooo.bot.application;
 
 import com.linecorp.bot.model.message.*;
 import lombok.extern.slf4j.*;
-import me.isooo.bot.domain.Currency;
+import me.isooo.bot.application.menu.*;
 import me.isooo.bot.domain.usermessage.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
-import org.springframework.util.*;
 
-import java.math.*;
-import java.time.*;
-import java.time.format.*;
 import java.util.*;
 
 @Slf4j
 @Service
 public class BotService {
-    public final static String HELP_TEXT = "HELP";
-    public final static String HELP_MESSAGE = "[시작]을 입력하시면,\n환율 조회를 시작할 수 있어요 :)";
-    private final static BigDecimal dummyCurrencyRate = new BigDecimal("1000.1929");
-
+    private final AllCommand allCommand;
     private final UserMessageRepository userMessageRepository;
 
-    public BotService(UserMessageRepository userMessageRepository) {
+    public BotService(AllCommand allCommand, UserMessageRepository userMessageRepository) {
+        this.allCommand = allCommand;
         this.userMessageRepository = userMessageRepository;
     }
 
     @Transactional
     public List<Message> handleTextContent(String userId, String userMessage) {
         log.info("userMessage: {}", userMessage);
-        final List<Message> messages = getMessages(userId, userMessage);
+        final Menu menu = allCommand.getMenu(userMessage);
+        final List<Message> messages = menu.getMessages(userId, userMessage);
         userMessageRepository.save(new UserMessage(userId, userMessage));
         return messages;
-    }
-
-    private List<Message> getMessages(String userId, String userMessage) {
-        if ("시작".equals(userMessage)) {
-            final StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.append("기준 통화 선택하기\n(??? → ???)\n");
-            Arrays.stream(Currency.values())
-                    .map(c -> c.name())
-                    .forEach(name -> stringBuilder.append("\n" + name));
-            final TextMessage textMessage = new TextMessage(stringBuilder.toString());
-            return Collections.singletonList(textMessage);
-        }
-
-        if (Currency.isCurrency(userMessage)) {
-            final UserMessage latestUserMessage = userMessageRepository.findFirstByUserIdOrderByIdDesc(userId).orElse(null);
-            log.info("latestUserMessage: {}", latestUserMessage);
-            final StringBuilder stringBuilder = new StringBuilder();
-            if (StringUtils.isEmpty(latestUserMessage) || !Currency.isCurrency(latestUserMessage.getMessage())) {
-                stringBuilder.append("상대 통화 선택하기\n(" + userMessage + " → ???)\n");
-                Arrays.stream(Currency.values())
-                        .map(c -> c.name())
-                        .filter(name -> !name.equals(userMessage))
-                        .forEach(name -> stringBuilder.append("\n" + name));
-                final TextMessage textMessage = new TextMessage(stringBuilder.toString());
-                return Collections.singletonList(textMessage);
-            }
-
-            final Currency baseCurrency = Currency.valueOf(latestUserMessage.getMessage());
-            final Currency counterCurrency = Currency.valueOf(userMessage);
-
-            stringBuilder.append(baseCurrency.name() + "/" + counterCurrency.name() + "의 환율 : ");
-            stringBuilder.append(dummyCurrencyRate + "\n\n");
-            stringBuilder.append("※ 기준 시각\n" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-
-            final TextMessage textMessage = new TextMessage(stringBuilder.toString());
-            return Collections.singletonList(textMessage);
-        }
-        final TextMessage textMessage = new TextMessage(HELP_MESSAGE);
-        return Collections.singletonList(textMessage);
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/BotService.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/BotService.java
@@ -2,8 +2,15 @@ package me.isooo.bot.application;
 
 import com.linecorp.bot.model.message.*;
 import lombok.extern.slf4j.*;
+import me.isooo.bot.domain.Currency;
+import me.isooo.bot.domain.usermessage.*;
 import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+import org.springframework.util.*;
 
+import java.math.*;
+import java.time.*;
+import java.time.format.*;
 import java.util.*;
 
 @Slf4j
@@ -11,13 +18,57 @@ import java.util.*;
 public class BotService {
     public final static String HELP_TEXT = "HELP";
     public final static String HELP_MESSAGE = "[시작]을 입력하시면,\n환율 조회를 시작할 수 있어요 :)";
+    private final static BigDecimal dummyCurrencyRate = new BigDecimal("1000.1929");
 
-    public List<Message> handleTextContent(String userMessage) {
+    private final UserMessageRepository userMessageRepository;
+
+    public BotService(UserMessageRepository userMessageRepository) {
+        this.userMessageRepository = userMessageRepository;
+    }
+
+    @Transactional
+    public List<Message> handleTextContent(String userId, String userMessage) {
         log.info("userMessage: {}", userMessage);
-        if (HELP_TEXT.equals(userMessage)) {
-            final TextMessage textMessage = new TextMessage(HELP_MESSAGE);
+        final List<Message> messages = getMessages(userId, userMessage);
+        userMessageRepository.save(new UserMessage(userId, userMessage));
+        return messages;
+    }
+
+    private List<Message> getMessages(String userId, String userMessage) {
+        if ("시작".equals(userMessage)) {
+            final StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append("기준 통화 선택하기\n(??? → ???)\n");
+            Arrays.stream(Currency.values())
+                    .map(c -> c.name())
+                    .forEach(name -> stringBuilder.append("\n" + name));
+            final TextMessage textMessage = new TextMessage(stringBuilder.toString());
             return Collections.singletonList(textMessage);
         }
-        return Collections.singletonList(new TextMessage("hello"));
+
+        if (Currency.isCurrency(userMessage)) {
+            final Optional<UserMessage> latestUserMessage = userMessageRepository.findFirstByUserIdOrderByIdDesc(userId);
+            final StringBuilder stringBuilder = new StringBuilder();
+            if (StringUtils.isEmpty(latestUserMessage) || !Currency.isCurrency(latestUserMessage.get().getMessage())) {
+                stringBuilder.append("상대 통화 선택하기\n(" + userMessage + " → ???)\n");
+                Arrays.stream(Currency.values())
+                        .map(c -> c.name())
+                        .filter(name -> !name.equals(userMessage))
+                        .forEach(name -> stringBuilder.append("\n" + name));
+                final TextMessage textMessage = new TextMessage(stringBuilder.toString());
+                return Collections.singletonList(textMessage);
+            }
+
+            final Currency baseCurrency = Currency.valueOf(latestUserMessage.get().getMessage());
+            final Currency counterCurrency = Currency.valueOf(userMessage);
+
+            stringBuilder.append(baseCurrency.name() + "/" + counterCurrency.name() + "의 환율 : ");
+            stringBuilder.append(dummyCurrencyRate + "\n\n");
+            stringBuilder.append("※ 기준 시각\n" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+
+            final TextMessage textMessage = new TextMessage(stringBuilder.toString());
+            return Collections.singletonList(textMessage);
+        }
+        final TextMessage textMessage = new TextMessage(HELP_MESSAGE);
+        return Collections.singletonList(textMessage);
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AllCommand.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AllCommand.java
@@ -1,0 +1,30 @@
+package me.isooo.bot.application.menu;
+
+import org.springframework.stereotype.*;
+
+@Component
+public class AllCommand {
+    private final StartMenu startMenu;
+    private final CurrencyMenu currencyMenu;
+    private final GuideMenu guideMenu;
+
+    public AllCommand(
+            StartMenu startMenu,
+            CurrencyMenu currencyMenu,
+            GuideMenu guideMenu
+    ) {
+        this.startMenu = startMenu;
+        this.currencyMenu = currencyMenu;
+        this.guideMenu = guideMenu;
+    }
+
+    public Menu getMenu(String userMessage) {
+        if (startMenu.Command.equals(userMessage)) {
+            return this.startMenu;
+        }
+        if (currencyMenu.isCurrencyPattern(userMessage)) {
+            return this.currencyMenu;
+        }
+        return this.guideMenu;
+    }
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/CurrencyMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/CurrencyMenu.java
@@ -29,14 +29,15 @@ public class CurrencyMenu implements Menu {
 
     @Override
     public List<Message> getMessages(String userId, String userMessage) {
-        // TODO : 제공되는 통화가 아닐 경우 걸러내기
-        // TODO : 기준 통화 선택인지 체크
-        // TODO : 상대 통화 선택인지 체크
-
         final UserMessage latestUserMessage = userMessageRepository.findFirstByUserIdOrderByIdDesc(userId).orElse(null);
         log.info("latestUserMessage: {}", latestUserMessage);
+
+        if (!Currency.isCurrency(userMessage)) {
+            return new ExceptionMenu().getMessages();
+        }
+
         final StringBuilder stringBuilder = new StringBuilder();
-        if (StringUtils.isEmpty(latestUserMessage) || !me.isooo.bot.domain.currency.Currency.isCurrency(latestUserMessage.getMessage())) {
+        if (StringUtils.isEmpty(latestUserMessage) || !Currency.isCurrency(latestUserMessage.getMessage())) {
             stringBuilder.append("상대 통화 선택하기\n(" + userMessage + " → ???)\n");
             Arrays.stream(me.isooo.bot.domain.currency.Currency.values())
                     .map(c -> c.name())

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/CurrencyMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/CurrencyMenu.java
@@ -1,0 +1,63 @@
+package me.isooo.bot.application.menu;
+
+import com.linecorp.bot.model.message.*;
+import lombok.extern.slf4j.*;
+import me.isooo.bot.domain.currency.Currency;
+import me.isooo.bot.domain.usermessage.*;
+import org.springframework.stereotype.*;
+import org.springframework.util.*;
+
+import java.math.*;
+import java.time.*;
+import java.time.format.*;
+import java.util.*;
+import java.util.regex.*;
+
+@Slf4j
+@Component
+public class CurrencyMenu implements Menu {
+    private static final Pattern CURRENCY_PATTERN = Pattern.compile("^([A-Z]{3})$");
+
+    // TODO : #20 환율 제공 API 연동 시, 제거 예정
+    private final static BigDecimal dummyCurrencyRate = new BigDecimal("1000.1929");
+
+    private final UserMessageRepository userMessageRepository;
+
+    public CurrencyMenu(UserMessageRepository userMessageRepository) {
+        this.userMessageRepository = userMessageRepository;
+    }
+
+    @Override
+    public List<Message> getMessages(String userId, String userMessage) {
+        // TODO : 제공되는 통화가 아닐 경우 걸러내기
+        // TODO : 기준 통화 선택인지 체크
+        // TODO : 상대 통화 선택인지 체크
+
+        final UserMessage latestUserMessage = userMessageRepository.findFirstByUserIdOrderByIdDesc(userId).orElse(null);
+        log.info("latestUserMessage: {}", latestUserMessage);
+        final StringBuilder stringBuilder = new StringBuilder();
+        if (StringUtils.isEmpty(latestUserMessage) || !me.isooo.bot.domain.currency.Currency.isCurrency(latestUserMessage.getMessage())) {
+            stringBuilder.append("상대 통화 선택하기\n(" + userMessage + " → ???)\n");
+            Arrays.stream(me.isooo.bot.domain.currency.Currency.values())
+                    .map(c -> c.name())
+                    .filter(name -> !name.equals(userMessage))
+                    .forEach(name -> stringBuilder.append("\n" + name));
+            final TextMessage textMessage = new TextMessage(stringBuilder.toString());
+            return Collections.singletonList(textMessage);
+        }
+
+        final Currency baseCurrency = Currency.valueOf(latestUserMessage.getMessage());
+        final Currency counterCurrency = Currency.valueOf(userMessage);
+
+        stringBuilder.append(baseCurrency.name() + "/" + counterCurrency.name() + "의 환율 : ");
+        stringBuilder.append(dummyCurrencyRate + "\n\n");
+        stringBuilder.append("※ 기준 시각\n" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+
+        final TextMessage textMessage = new TextMessage(stringBuilder.toString());
+        return Collections.singletonList(textMessage);
+    }
+
+    public boolean isCurrencyPattern(final String pattern) {
+        return CURRENCY_PATTERN.matcher(pattern).matches();
+    }
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/ExceptionMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/ExceptionMenu.java
@@ -1,0 +1,14 @@
+package me.isooo.bot.application.menu;
+
+import com.linecorp.bot.model.message.*;
+import org.springframework.stereotype.*;
+
+import java.util.*;
+
+@Component
+public class ExceptionMenu {
+    public List<Message> getMessages() {
+        final TextMessage textMessage = new TextMessage("통화를 다시 한 번 확인해주세요 :)");
+        return Collections.singletonList(textMessage);
+    }
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/GuideMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/GuideMenu.java
@@ -1,0 +1,18 @@
+package me.isooo.bot.application.menu;
+
+import com.linecorp.bot.model.message.*;
+import org.springframework.stereotype.*;
+
+import java.util.*;
+
+@Component
+public class GuideMenu implements Menu {
+    public final static String HELP_TEXT = "HELP";
+    public final static String HELP_MESSAGE = "[시작]을 입력하시면,\n환율 조회를 시작할 수 있어요 :)";
+
+    @Override
+    public List<Message> getMessages(String userId, String userMessage) {
+        final TextMessage textMessage = new TextMessage(HELP_MESSAGE);
+        return Collections.singletonList(textMessage);
+    }
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/GuideMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/GuideMenu.java
@@ -12,7 +12,11 @@ public class GuideMenu implements Menu {
 
     @Override
     public List<Message> getMessages(String userId, String userMessage) {
+        final List<Message> messages = new ArrayList<>();
+        final StickerMessage stickerMessage = new StickerMessage("1", "2");
         final TextMessage textMessage = new TextMessage(HELP_MESSAGE);
-        return Collections.singletonList(textMessage);
+        messages.add(stickerMessage);
+        messages.add(textMessage);
+        return Collections.unmodifiableList(messages);
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/Menu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/Menu.java
@@ -1,0 +1,9 @@
+package me.isooo.bot.application.menu;
+
+import com.linecorp.bot.model.message.*;
+
+import java.util.*;
+
+public interface Menu {
+    List<Message> getMessages(String userId, String userMessage);
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/StartMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/StartMenu.java
@@ -1,0 +1,23 @@
+package me.isooo.bot.application.menu;
+
+import com.linecorp.bot.model.message.*;
+import me.isooo.bot.domain.currency.Currency;
+import org.springframework.stereotype.*;
+
+import java.util.*;
+
+@Component
+public class StartMenu implements Menu {
+    public static final String Command = "시작";
+
+    @Override
+    public List<Message> getMessages(String userId, String userMessage) {
+        final StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("기준 통화 선택하기\n(??? → ???)\n");
+        Arrays.stream(Currency.values())
+                .map(c -> c.name())
+                .forEach(name -> stringBuilder.append("\n" + name));
+        final TextMessage textMessage = new TextMessage(stringBuilder.toString());
+        return Collections.singletonList(textMessage);
+    }
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/Currency.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/Currency.java
@@ -1,0 +1,32 @@
+package me.isooo.bot.domain;
+
+import lombok.*;
+
+import java.util.*;
+
+@Getter
+public enum Currency {
+    KRW("원", "₩"),
+    USD("달러", "$"),
+    JPY("엔", "¥"),
+    EUR("유로", "€"),
+    CNY("런민비", "¥"),
+    GBP("파운드", "£"),
+    AUD("달러", "$"),
+    CAD("달러", "C$"),
+    HKD("달러", "HK$"),
+    THB("바트", "฿");
+
+    private final String unit;
+    private final String symbol;
+
+    Currency(String unit, String symbol) {
+        this.unit = unit;
+        this.symbol = symbol;
+    }
+
+    public static boolean isCurrency(String text) {
+        return Arrays.stream(Currency.values())
+                .anyMatch(c -> c.name().equals(text));
+    }
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/currency/Currency.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/currency/Currency.java
@@ -1,4 +1,4 @@
-package me.isooo.bot.domain;
+package me.isooo.bot.domain.currency;
 
 import lombok.*;
 

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/usermessage/UserMessage.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/usermessage/UserMessage.java
@@ -1,0 +1,22 @@
+package me.isooo.bot.domain.usermessage;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@ToString
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Entity
+public class UserMessage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String userId;
+    private String message;
+
+    public UserMessage(String userId, String message) {
+        this.userId = userId;
+        this.message = message;
+    }
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/usermessage/UserMessageRepository.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/usermessage/UserMessageRepository.java
@@ -1,0 +1,9 @@
+package me.isooo.bot.domain.usermessage;
+
+import org.springframework.data.jpa.repository.*;
+
+import java.util.*;
+
+public interface UserMessageRepository extends JpaRepository<UserMessage, Long> {
+    Optional<UserMessage> findFirstByUserIdOrderByIdDesc(String userId);
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/ui/BotController.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/ui/BotController.java
@@ -10,6 +10,7 @@ import com.linecorp.bot.spring.boot.annotation.*;
 import lombok.*;
 import lombok.extern.slf4j.*;
 import me.isooo.bot.application.*;
+import me.isooo.bot.application.menu.*;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -38,7 +39,7 @@ public class BotController {
     public void handleStickerMessageEvent(MessageEvent<StickerMessageContent> event) {
         log.info("event: {}", event);
         final String userId = event.getSource().getUserId();
-        final List<Message> messages = botService.handleTextContent(userId, BotService.HELP_TEXT);
+        final List<Message> messages = botService.handleTextContent(userId, GuideMenu.HELP_TEXT);
         reply(event.getReplyToken(), messages);
     }
 

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/ui/BotController.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/ui/BotController.java
@@ -30,7 +30,7 @@ public class BotController {
         log.info("event: {}", event);
         final String userMessage = event.getMessage().getText().toUpperCase();
         final String userId = event.getSource().getUserId();
-        final List<Message> messages = botService.handleTextContent(userMessage);
+        final List<Message> messages = botService.handleTextContent(userId, userMessage);
         reply(event.getReplyToken(), messages);
     }
 
@@ -38,7 +38,7 @@ public class BotController {
     public void handleStickerMessageEvent(MessageEvent<StickerMessageContent> event) {
         log.info("event: {}", event);
         final String userId = event.getSource().getUserId();
-        final List<Message> messages = botService.handleTextContent(BotService.HELP_TEXT);
+        final List<Message> messages = botService.handleTextContent(userId, BotService.HELP_TEXT);
         reply(event.getReplyToken(), messages);
     }
 

--- a/currency_rate_chatbot/currency-rate-bot/src/test/java/me/isooo/bot/application/BotServiceTest.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/test/java/me/isooo/bot/application/BotServiceTest.java
@@ -1,6 +1,7 @@
 package me.isooo.bot.application;
 
 import com.linecorp.bot.model.message.*;
+import me.isooo.bot.application.menu.*;
 import me.isooo.bot.domain.usermessage.*;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.*;
@@ -26,7 +27,7 @@ class BotServiceTest {
     void helpGuideText() {
         // given
         final String userId = "test001";
-        final String userMessage = "HELP";
+        final String userMessage = "help";
 
         // when
         final List<Message> messages = service.handleTextContent(userId, userMessage);
@@ -34,7 +35,7 @@ class BotServiceTest {
         final String text = message.getText();
 
         // then
-        assertThat(text).isEqualTo(BotService.HELP_MESSAGE);
+        assertThat(text).isEqualTo(GuideMenu.HELP_MESSAGE);
     }
 
     @DisplayName("시작이 입력되었을 때, 기준 통화 목록이 응답되는지 테스트")
@@ -84,5 +85,22 @@ class BotServiceTest {
 
         // then
         assertThat(text.split("\n")[0]).isEqualTo("KRW/USD의 환율 : 1000.1929");
+    }
+
+    @DisplayName("제공되지 않는 통화 입력 시 예외 메시지 테스트")
+    @Test
+    void unAllowableCurrencyHandle() {
+        // given
+        final String userId = "test001";
+        final String userMessage = "AAA";
+        this.userMessageRepository.save(new UserMessage(userId, "KRW"));
+
+        // when
+        final List<Message> messages = service.handleTextContent(userId, userMessage);
+        final TextMessage message = (TextMessage) messages.get(0);
+        final String text = message.getText();
+
+        // then
+        assertThat(text).isEqualTo("통화를 다시 한 번 확인해주세요 :)");
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/test/java/me/isooo/bot/application/BotServiceTest.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/test/java/me/isooo/bot/application/BotServiceTest.java
@@ -1,10 +1,11 @@
 package me.isooo.bot.application;
 
 import com.linecorp.bot.model.message.*;
-import lombok.*;
+import me.isooo.bot.domain.usermessage.*;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.boot.test.context.*;
+import org.springframework.transaction.annotation.*;
 
 import java.util.*;
 
@@ -12,22 +13,76 @@ import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("BotService 테스트")
 @SpringBootTest
+@Transactional
 class BotServiceTest {
+    @Autowired
+    private UserMessageRepository userMessageRepository;
+
     @Autowired
     private BotService service;
 
     @DisplayName("help가 입력되었을 때, 가이드 텍스트가 reply되는지 테스트")
     @Test
-    void name() {
+    void helpGuideText() {
         // given
+        final String userId = "test001";
         final String userMessage = "HELP";
 
         // when
-        final List<Message> messages = service.handleTextContent(userMessage);
+        final List<Message> messages = service.handleTextContent(userId, userMessage);
         final TextMessage message = (TextMessage) messages.get(0);
         final String text = message.getText();
 
         // then
         assertThat(text).isEqualTo(BotService.HELP_MESSAGE);
+    }
+
+    @DisplayName("시작이 입력되었을 때, 기준 통화 목록이 응답되는지 테스트")
+    @Test
+    void baseCurrencyGuideText() {
+        // given
+        final String userId = "test001";
+        final String userMessage = "시작";
+
+        // when
+        final List<Message> messages = service.handleTextContent(userId, userMessage);
+        final TextMessage message = (TextMessage) messages.get(0);
+        final String text = message.getText();
+
+        // then
+        assertThat(text.split("\n")[0]).isEqualTo("기준 통화 선택하기");
+    }
+
+    @DisplayName("통화가 최초 입력되었을 때, 기준 통화로 인식하는 지 테스트")
+    @Test
+    void baseCurrencyHandle() {
+        // given
+        final String userId = "test001";
+        final String userMessage = "KRW";
+
+        // when
+        final List<Message> messages = service.handleTextContent(userId, userMessage);
+        final TextMessage message = (TextMessage) messages.get(0);
+        final String text = message.getText();
+
+        // then
+        assertThat(text.split("\n")[0]).isEqualTo("상대 통화 선택하기");
+    }
+
+    @DisplayName("통화가 입력되었을 때, 상대 통화로 인식하는 지 테스트")
+    @Test
+    void counterCurrencyHandle() {
+        // given
+        final String userId = "test001";
+        final String userMessage = "USD";
+        this.userMessageRepository.save(new UserMessage(userId, "KRW"));
+
+        // when
+        final List<Message> messages = service.handleTextContent(userId, userMessage);
+        final TextMessage message = (TextMessage) messages.get(0);
+        final String text = message.getText();
+
+        // then
+        assertThat(text.split("\n")[0]).isEqualTo("KRW/USD의 환율 : 1000.1929");
     }
 }


### PR DESCRIPTION
#7
- 기준 통화 입력 > 상대 통화 입력 > 환율 정보 제공
- 사용자 입력값 저장 기능 추가
    - h2 인메모리데이터베이스 사용
    - 사용자 최근 입력값을 조회하여, 값이 Currency의 value이면 상대 통화를 입력한 것으로 처리
- 리팩토링
    - Service 클래스의 역할 분담 > AllCommand를 통해 Menu를 가져오고, Menu의 getMessages를 호출하는 방식으로 수정
- 제공되지 않는 Currency 입력 시, 예외 처리
- 가이드 텍스트에 스티커 메시지 추가
- 환율 정보(Dummy Data)를 제공하는 기능에 대한 TC 작성
- README 수정
    - H2 스펙 추가