### PR TITLE
feature/issue-11-amount : 환전 기능을 제공

### DIFF
--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AllCommand.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AllCommand.java
@@ -7,17 +7,20 @@ public class AllCommand {
     private final StartMenu startMenu;
     private final CurrencyMenu currencyMenu;
     private final AmountMenu amountMenu;
+    private final AmountResultMenu amountResultMenu;
     private final GuideMenu guideMenu;
 
     public AllCommand(
             StartMenu startMenu,
             CurrencyMenu currencyMenu,
             AmountMenu amountMenu,
+            AmountResultMenu amountResultMenu,
             GuideMenu guideMenu
     ) {
         this.startMenu = startMenu;
         this.currencyMenu = currencyMenu;
         this.amountMenu = amountMenu;
+        this.amountResultMenu = amountResultMenu;
         this.guideMenu = guideMenu;
     }
 
@@ -30,6 +33,9 @@ public class AllCommand {
         }
         if (amountMenu.matches(userMessage)) {
             return this.amountMenu;
+        }
+        if (amountResultMenu.matches(userMessage)) {
+            return this.amountResultMenu;
         }
         return this.guideMenu;
     }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AllCommand.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AllCommand.java
@@ -6,24 +6,30 @@ import org.springframework.stereotype.*;
 public class AllCommand {
     private final StartMenu startMenu;
     private final CurrencyMenu currencyMenu;
+    private final AmountMenu amountMenu;
     private final GuideMenu guideMenu;
 
     public AllCommand(
             StartMenu startMenu,
             CurrencyMenu currencyMenu,
+            AmountMenu amountMenu,
             GuideMenu guideMenu
     ) {
         this.startMenu = startMenu;
         this.currencyMenu = currencyMenu;
+        this.amountMenu = amountMenu;
         this.guideMenu = guideMenu;
     }
 
     public Menu getMenu(String userMessage) {
-        if (startMenu.Command.equals(userMessage)) {
+        if (startMenu.matches(userMessage)) {
             return this.startMenu;
         }
-        if (currencyMenu.isCurrencyPattern(userMessage)) {
+        if (currencyMenu.matches(userMessage)) {
             return this.currencyMenu;
+        }
+        if (amountMenu.matches(userMessage)) {
+            return this.amountMenu;
         }
         return this.guideMenu;
     }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountMenu.java
@@ -1,0 +1,17 @@
+package me.isooo.bot.application.menu;
+
+import com.linecorp.bot.model.message.*;
+
+import java.util.*;
+
+public class AmountMenu implements Menu {
+    public static final String Command = "환전 금액 계산하기";
+
+    @Override
+    public List<Message> getMessages(String userId, String userMessage) {
+        // TODO : 해당 user의 최근 조회 CurrnecyRate 가져오기
+
+        // TODO : base currency의 unit을 아래 괄호 사이에 넣어줄 것
+        return Collections.singletonList(new TextMessage("환전할 금액(" + "" + ")를 숫자로 입력해주세요."));
+    }
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountMenu.java
@@ -1,17 +1,40 @@
 package me.isooo.bot.application.menu;
 
 import com.linecorp.bot.model.message.*;
+import lombok.extern.slf4j.*;
+import me.isooo.bot.domain.currency.Currency;
+import me.isooo.bot.domain.usermessage.*;
+import org.springframework.stereotype.*;
 
 import java.util.*;
 
+@Slf4j
+@Component
 public class AmountMenu implements Menu {
     public static final String Command = "환전 금액 계산하기";
 
+    private final UserMessageRepository userMessageRepository;
+
+    public AmountMenu(UserMessageRepository userMessageRepository) {
+        this.userMessageRepository = userMessageRepository;
+    }
+
     @Override
     public List<Message> getMessages(String userId, String userMessage) {
-        // TODO : 해당 user의 최근 조회 CurrnecyRate 가져오기
+        log.info("userId: {}, userMessage: {}", userId, userMessage);
+        final UserMessage userCurrencyPair = userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(userId, MessageType.CURRENCY_PAIR).get();
+        log.info("userCurrencyPair: {}", userCurrencyPair);
+        try {
+            final String userCurrencyPairMessage = userCurrencyPair.getMessage();
+            final Currency base = Currency.valueOf(userCurrencyPairMessage.substring(0, 3));
+            return Collections.singletonList(new TextMessage("환전할 금액(" + base.getUnit() + ")을 숫자로 입력해주세요."));
+        } catch (IllegalArgumentException e) {
+            log.info("[IllegalArgumentException] Currency pair does not exist, userMessage : {}, userCurrencyPair : {}", userMessage, userCurrencyPair);
+            return Collections.unmodifiableList(ExceptionMenu.currencyPairEmpty(userId, userMessage));
+        }
+    }
 
-        // TODO : base currency의 unit을 아래 괄호 사이에 넣어줄 것
-        return Collections.singletonList(new TextMessage("환전할 금액(" + "" + ")를 숫자로 입력해주세요."));
+    public boolean matches(String userMessage) {
+        return AmountMenu.Command.equals(userMessage);
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountMenu.java
@@ -22,14 +22,17 @@ public class AmountMenu implements Menu {
     @Override
     public List<Message> getMessages(String userId, String userMessage) {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
-        final UserMessage userCurrencyPair = userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(userId, MessageType.CURRENCY_PAIR).get();
-        log.info("userCurrencyPair: {}", userCurrencyPair);
         try {
+            final UserMessage userCurrencyPair = userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(userId, MessageType.CURRENCY_PAIR).get();
+            log.info("userCurrencyPair: {}", userCurrencyPair);
             final String userCurrencyPairMessage = userCurrencyPair.getMessage();
             final Currency base = Currency.valueOf(userCurrencyPairMessage.substring(0, 3));
             return Collections.singletonList(new TextMessage("환전할 금액(" + base.getUnit() + ")을 숫자로 입력해주세요."));
         } catch (IllegalArgumentException e) {
-            log.info("[IllegalArgumentException] Currency pair does not exist, userMessage : {}, userCurrencyPair : {}", userMessage, userCurrencyPair);
+            log.error("[IllegalArgumentException]", e);
+            return new StartMenu().getMessages(userId, userMessage);
+        } catch (NoSuchElementException e) {
+            log.error("[NoSuchElementException]", e);
             return Collections.unmodifiableList(ExceptionMenu.currencyPairEmpty(userId, userMessage));
         }
     }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountMenu.java
@@ -20,6 +20,11 @@ public class AmountMenu implements Menu {
     }
 
     @Override
+    public boolean matches(String userMessage) {
+        return AmountMenu.Command.equals(userMessage);
+    }
+
+    @Override
     public List<Message> getMessages(String userId, String userMessage) {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
         try {
@@ -35,9 +40,5 @@ public class AmountMenu implements Menu {
             log.error("[NoSuchElementException]", e);
             return Collections.unmodifiableList(ExceptionMenu.currencyPairEmpty(userId, userMessage));
         }
-    }
-
-    public boolean matches(String userMessage) {
-        return AmountMenu.Command.equals(userMessage);
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
@@ -38,13 +38,8 @@ public class AmountResultMenu implements Menu {
     }
 
     private TextMessage getAmountResultMessage(String userMessage, CurrencyRate currencyRate) {
-        final String formalizedAmount = CurrencyUtils.getFormalizedFigures(currencyRate.calculateAmount(new BigDecimal(userMessage)));
-        return new TextMessage(userMessage
-                + currencyRate.getBase().getUnit()
-                + " → "
-                + formalizedAmount
-                + currencyRate.getCounter().getUnit()
-                + "입니다."
+        return new TextMessage(
+                CurrencyUtils.amountResultTextMessageFormatting(userMessage, currencyRate)
         );
     }
 

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
@@ -1,0 +1,54 @@
+package me.isooo.bot.application.menu;
+
+import com.linecorp.bot.model.message.*;
+import lombok.extern.slf4j.*;
+import me.isooo.bot.domain.currency.*;
+import me.isooo.bot.domain.usermessage.*;
+import me.isooo.bot.support.utils.*;
+import org.springframework.stereotype.*;
+
+import java.math.*;
+import java.util.*;
+
+@Slf4j
+@Component
+public class AmountResultMenu implements Menu {
+    private final UserMessageRepository userMessageRepository;
+
+    public AmountResultMenu(UserMessageRepository userMessageRepository) {
+        this.userMessageRepository = userMessageRepository;
+    }
+
+    @Override
+    public List<Message> getMessages(String userId, String userMessage) {
+        log.info("userId: {}, userMessage: {}", userId, userMessage);
+        // TODO : #13 허용 가능한 포멧인지 체크 (CurrencyUtils.isAllowableAmountPattern())
+
+        final UserMessage userCurrencyPair = userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(userId, MessageType.CURRENCY_PAIR).get();
+        log.info("userCurrencyPair: {}", userCurrencyPair);
+        try {
+            final String userCurrencyPairMessage = userCurrencyPair.getMessage();
+            final CurrencyRate currencyRate = CurrencyUtils.convert(userCurrencyPairMessage);
+            final TextMessage textMessage = getAmountResultMessage(userMessage, currencyRate);
+            return Collections.singletonList(textMessage);
+        } catch (IllegalArgumentException e) {
+            log.info("[IllegalArgumentException] Currency pair does not exist, userMessage : {}, userCurrencyPair : {}", userMessage, userCurrencyPair);
+            return Collections.unmodifiableList(ExceptionMenu.currencyPairEmpty(userId, userMessage));
+        }
+    }
+
+    private TextMessage getAmountResultMessage(String userMessage, CurrencyRate currencyRate) {
+        final String formalizedAmount = CurrencyUtils.getFormalizedFigures(currencyRate.calculateAmount(new BigDecimal(userMessage)));
+        return new TextMessage(userMessage
+                + currencyRate.getBase().getUnit()
+                + " → "
+                + formalizedAmount
+                + currencyRate.getCounter().getUnit()
+                + "입니다."
+        );
+    }
+
+    public boolean matches(String userMessage) {
+        return CurrencyUtils.isAmountPattern(userMessage);
+    }
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
@@ -21,6 +21,11 @@ public class AmountResultMenu implements Menu {
     }
 
     @Override
+    public boolean matches(String userMessage) {
+        return CurrencyUtils.isAmountPattern(userMessage);
+    }
+
+    @Override
     public List<Message> getMessages(String userId, String userMessage) {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
         // TODO : #13 허용 가능한 포멧인지 체크 (CurrencyUtils.isAllowableAmountPattern())
@@ -54,9 +59,5 @@ public class AmountResultMenu implements Menu {
                                 )
                         )
                 ).build();
-    }
-
-    public boolean matches(String userMessage) {
-        return CurrencyUtils.isAmountPattern(userMessage);
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
@@ -24,15 +24,15 @@ public class AmountResultMenu implements Menu {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
         // TODO : #13 허용 가능한 포멧인지 체크 (CurrencyUtils.isAllowableAmountPattern())
 
-        final UserMessage userCurrencyPair = userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(userId, MessageType.CURRENCY_PAIR).get();
-        log.info("userCurrencyPair: {}", userCurrencyPair);
         try {
+            final UserMessage userCurrencyPair = userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(userId, MessageType.CURRENCY_PAIR).get();
+            log.info("userCurrencyPair: {}", userCurrencyPair);
             final String userCurrencyPairMessage = userCurrencyPair.getMessage();
             final CurrencyRate currencyRate = CurrencyUtils.convert(userCurrencyPairMessage);
             final TextMessage textMessage = getAmountResultMessage(userMessage, currencyRate);
             return Collections.singletonList(textMessage);
         } catch (IllegalArgumentException e) {
-            log.info("[IllegalArgumentException] Currency pair does not exist, userMessage : {}, userCurrencyPair : {}", userMessage, userCurrencyPair);
+            log.error("[IllegalArgumentException]", e);
             return Collections.unmodifiableList(ExceptionMenu.currencyPairEmpty(userId, userMessage));
         }
     }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
@@ -1,13 +1,14 @@
 package me.isooo.bot.application.menu;
 
+import com.linecorp.bot.model.action.*;
 import com.linecorp.bot.model.message.*;
+import com.linecorp.bot.model.message.quickreply.*;
 import lombok.extern.slf4j.*;
 import me.isooo.bot.domain.currency.*;
 import me.isooo.bot.domain.usermessage.*;
 import me.isooo.bot.support.utils.*;
 import org.springframework.stereotype.*;
 
-import java.math.*;
 import java.util.*;
 
 @Slf4j
@@ -38,9 +39,21 @@ public class AmountResultMenu implements Menu {
     }
 
     private TextMessage getAmountResultMessage(String userMessage, CurrencyRate currencyRate) {
-        return new TextMessage(
+        final TextMessage textMessage = new TextMessage(
                 CurrencyUtils.amountResultTextMessageFormatting(userMessage, currencyRate)
         );
+
+        return textMessage
+                .toBuilder()
+                .quickReply(
+                        QuickReply.items(
+                                Collections.singletonList(
+                                        QuickReplyItem.builder()
+                                                .action(new MessageAction("처음으로 돌아가기", StartMenu.Command))
+                                                .build()
+                                )
+                        )
+                ).build();
     }
 
     public boolean matches(String userMessage) {

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/CurrencyMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/CurrencyMenu.java
@@ -4,7 +4,6 @@ import com.linecorp.bot.model.action.*;
 import com.linecorp.bot.model.message.*;
 import com.linecorp.bot.model.message.quickreply.*;
 import lombok.extern.slf4j.*;
-import me.isooo.bot.domain.currency.Currency;
 import me.isooo.bot.domain.currency.*;
 import me.isooo.bot.support.utils.*;
 import org.springframework.stereotype.*;
@@ -14,9 +13,6 @@ import java.util.*;
 @Slf4j
 @Component
 public class CurrencyMenu implements Menu {
-    private static final String BASE = "base";
-    private static final String COUNTER = "counter";
-
     @Override
     public List<Message> getMessages(String userId, String userMessage) {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
@@ -34,7 +30,7 @@ public class CurrencyMenu implements Menu {
     }
 
     private TextMessage getCurrencyRateMessage(String userMessage) {
-        final CurrencyRate currencyRate = convert(userMessage);
+        final CurrencyRate currencyRate = CurrencyUtils.convert(userMessage);
         final TextMessage textMessage = new TextMessage(
                 // TODO : #12 업데이트 시간 표기
                 CurrencyUtils.currencyRateTextMessageFormatting(currencyRate)
@@ -54,21 +50,5 @@ public class CurrencyMenu implements Menu {
                                 )
                         )
                 ).build();
-    }
-
-    private CurrencyRate convert(final String text) {
-        final Map<String, Currency> currencyPair = extractCurrencyPair(text);
-        final Currency base = currencyPair.get(BASE);
-        final Currency counter = currencyPair.get(COUNTER);
-        return new CurrencyRate(base, counter);
-    }
-
-    private static Map<String, Currency> extractCurrencyPair(final String text) {
-        final Map<String, Currency> map = new HashMap<>();
-        final Currency base = Currency.valueOf(text.substring(0, 3));
-        final Currency counter = Currency.valueOf(text.substring(3));
-        map.put(BASE, base);
-        map.put(COUNTER, counter);
-        return map;
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/CurrencyMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/CurrencyMenu.java
@@ -20,7 +20,7 @@ public class CurrencyMenu implements Menu {
             final TextMessage textMessage = getCurrencyRateMessage(userMessage);
             return Collections.singletonList(textMessage);
         } catch (IllegalArgumentException e) {
-            log.info("[IllegalArgumentException] invalid currency, userMessage : {}", userMessage);
+            log.error("[IllegalArgumentException]", e);
             return Collections.unmodifiableList(ExceptionMenu.unallowableCurrency(userId, userMessage));
         }
     }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/CurrencyMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/CurrencyMenu.java
@@ -14,6 +14,11 @@ import java.util.*;
 @Component
 public class CurrencyMenu implements Menu {
     @Override
+    public boolean matches(String userMessage) {
+        return CurrencyUtils.isCurrencyRatePattern(userMessage);
+    }
+
+    @Override
     public List<Message> getMessages(String userId, String userMessage) {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
         try {
@@ -23,10 +28,6 @@ public class CurrencyMenu implements Menu {
             log.error("[IllegalArgumentException]", e);
             return Collections.unmodifiableList(ExceptionMenu.unallowableCurrency(userId, userMessage));
         }
-    }
-
-    public boolean matches(String userMessage) {
-        return CurrencyUtils.isCurrencyRatePattern(userMessage);
     }
 
     private TextMessage getCurrencyRateMessage(String userMessage) {

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/CurrencyMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/CurrencyMenu.java
@@ -29,12 +29,12 @@ public class CurrencyMenu implements Menu {
 
     @Override
     public List<Message> getMessages(String userId, String userMessage) {
-        final UserMessage latestUserMessage = userMessageRepository.findFirstByUserIdOrderByIdDesc(userId).orElse(null);
-        log.info("latestUserMessage: {}", latestUserMessage);
-
         if (!Currency.isCurrency(userMessage)) {
             return new ExceptionMenu().getMessages();
         }
+
+        final UserMessage latestUserMessage = userMessageRepository.findFirstByUserIdOrderByIdDesc(userId).orElse(null);
+        log.info("latestUserMessage: {}", latestUserMessage);
 
         final StringBuilder stringBuilder = new StringBuilder();
         if (StringUtils.isEmpty(latestUserMessage) || !Currency.isCurrency(latestUserMessage.getMessage())) {

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/ExceptionMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/ExceptionMenu.java
@@ -1,14 +1,32 @@
 package me.isooo.bot.application.menu;
 
 import com.linecorp.bot.model.message.*;
+import lombok.extern.slf4j.*;
 import org.springframework.stereotype.*;
 
 import java.util.*;
 
+@Slf4j
 @Component
 public class ExceptionMenu {
-    public List<Message> getMessages() {
-        final TextMessage textMessage = new TextMessage("통화를 다시 한 번 확인해주세요 :)");
-        return Collections.singletonList(textMessage);
+    private static final String UNALLOWABLE_CURRENCY_MESSAGE = "가능한 통화 목록을 다시 확인해주세요 :)";
+    private static final String CURRENCY_PAIR_EMPTY_MESSAGE = "환율 정보를 먼저 입력해주세요 :)";
+
+    public static List<Message> unallowableCurrency(String userId, String userMessage) {
+        log.info("userId: {}, userMessage: {}", userId, userMessage);
+        return getMessages(userId, userMessage, UNALLOWABLE_CURRENCY_MESSAGE);
+    }
+
+    public static List<Message> currencyPairEmpty(String userId, String userMessage) {
+        log.info("userId: {}, userMessage: {}", userId, userMessage);
+        return getMessages(userId, userMessage, CURRENCY_PAIR_EMPTY_MESSAGE);
+    }
+
+    private static List<Message> getMessages(String userId, String userMessage, String message) {
+        final List<Message> messages = new ArrayList<>();
+        final TextMessage textMessage = new TextMessage(message);
+        messages.add(textMessage);
+        messages.addAll(new StartMenu().getMessages(userId, userMessage));
+        return Collections.unmodifiableList(messages);
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/GuideMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/GuideMenu.java
@@ -13,6 +13,11 @@ public class GuideMenu implements Menu {
     public final static String HELP_MESSAGE = "[시작]을 입력하시면,\n환율 조회를 시작할 수 있어요 :)";
 
     @Override
+    public boolean matches(String userMessage) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<Message> getMessages(String userId, String userMessage) {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
         final List<Message> messages = new ArrayList<>();

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/GuideMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/GuideMenu.java
@@ -1,10 +1,12 @@
 package me.isooo.bot.application.menu;
 
 import com.linecorp.bot.model.message.*;
+import lombok.extern.slf4j.*;
 import org.springframework.stereotype.*;
 
 import java.util.*;
 
+@Slf4j
 @Component
 public class GuideMenu implements Menu {
     public final static String HELP_TEXT = "HELP";
@@ -12,6 +14,7 @@ public class GuideMenu implements Menu {
 
     @Override
     public List<Message> getMessages(String userId, String userMessage) {
+        log.info("userId: {}, userMessage: {}", userId, userMessage);
         final List<Message> messages = new ArrayList<>();
         final StickerMessage stickerMessage = new StickerMessage("1", "2");
         final TextMessage textMessage = new TextMessage(HELP_MESSAGE);

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/Menu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/Menu.java
@@ -5,5 +5,7 @@ import com.linecorp.bot.model.message.*;
 import java.util.*;
 
 public interface Menu {
+    boolean matches(String userMessage);
+
     List<Message> getMessages(String userId, String userMessage);
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/StartMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/StartMenu.java
@@ -13,6 +13,11 @@ public class StartMenu implements Menu {
     public static final String Command = "시작";
 
     @Override
+    public boolean matches(String userMessage) {
+        return StartMenu.Command.equals(userMessage);
+    }
+
+    @Override
     public List<Message> getMessages(String userId, String userMessage) {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
         final List<Message> messages = new ArrayList<>();
@@ -27,9 +32,5 @@ public class StartMenu implements Menu {
         messages.add(textMessage1);
         messages.add(textMessage2);
         return Collections.unmodifiableList(messages);
-    }
-
-    public boolean matches(String userMessage) {
-        return StartMenu.Command.equals(userMessage);
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/StartMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/StartMenu.java
@@ -1,23 +1,35 @@
 package me.isooo.bot.application.menu;
 
 import com.linecorp.bot.model.message.*;
+import lombok.extern.slf4j.*;
 import me.isooo.bot.domain.currency.Currency;
 import org.springframework.stereotype.*;
 
 import java.util.*;
 
+@Slf4j
 @Component
 public class StartMenu implements Menu {
     public static final String Command = "시작";
 
     @Override
     public List<Message> getMessages(String userId, String userMessage) {
+        log.info("userId: {}, userMessage: {}", userId, userMessage);
+        final List<Message> messages = new ArrayList<>();
+        final TextMessage textMessage1 = new TextMessage("원하시는 환율에 대한 통화를 차례로 입력해주세요.\n" +
+                "e.g. 1유로(EUR) 대비 원화(KRW)가 궁금할 땐\n[EURKRW]를 입력하시면 됩니다 :)");
         final StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append("기준 통화 선택하기\n(??? → ???)\n");
+        stringBuilder.append("※ 가능한 통화\n");
         Arrays.stream(Currency.values())
                 .map(c -> c.name())
                 .forEach(name -> stringBuilder.append("\n" + name));
-        final TextMessage textMessage = new TextMessage(stringBuilder.toString());
-        return Collections.singletonList(textMessage);
+        final TextMessage textMessage2 = new TextMessage(stringBuilder.toString());
+        messages.add(textMessage1);
+        messages.add(textMessage2);
+        return Collections.unmodifiableList(messages);
+    }
+
+    public boolean matches(String userMessage) {
+        return StartMenu.Command.equals(userMessage);
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/currency/CurrencyRate.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/currency/CurrencyRate.java
@@ -1,10 +1,7 @@
 package me.isooo.bot.domain.currency;
 
 import lombok.*;
-import org.hibernate.annotations.*;
 
-import javax.persistence.*;
-import javax.persistence.Entity;
 import java.math.*;
 import java.time.*;
 

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/currency/CurrencyRate.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/currency/CurrencyRate.java
@@ -21,4 +21,8 @@ public class CurrencyRate {
         this.counter = counter;
         this.createdTime = LocalDateTime.now();
     }
+
+    public BigDecimal calculateAmount(BigDecimal money) {
+        return money.multiply(this.rate);
+    }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/currency/CurrencyRate.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/currency/CurrencyRate.java
@@ -25,4 +25,11 @@ public class CurrencyRate {
     public BigDecimal calculateAmount(BigDecimal money) {
         return money.multiply(this.rate);
     }
+    public String getBaseUnit() {
+        return base.getUnit();
+    }
+
+    public String getCounterUnit() {
+        return counter.getUnit();
+    }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/currency/CurrencyRate.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/currency/CurrencyRate.java
@@ -1,0 +1,27 @@
+package me.isooo.bot.domain.currency;
+
+import lombok.*;
+import org.hibernate.annotations.*;
+
+import javax.persistence.*;
+import javax.persistence.Entity;
+import java.math.*;
+import java.time.*;
+
+@ToString
+@Getter
+public class CurrencyRate {
+    private Currency base;
+    private Currency counter;
+
+    // TODO : #20 환율 제공 API 연동 시, 제거 예정
+    private final BigDecimal rate = new BigDecimal("1000.1929");
+
+    private LocalDateTime createdTime;
+
+    public CurrencyRate(Currency base, Currency counter) {
+        this.base = base;
+        this.counter = counter;
+        this.createdTime = LocalDateTime.now();
+    }
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/usermessage/MessageType.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/usermessage/MessageType.java
@@ -1,0 +1,17 @@
+package me.isooo.bot.domain.usermessage;
+
+import lombok.*;
+import me.isooo.bot.support.utils.*;
+
+@Getter
+public enum MessageType {
+    TEXT,
+    CURRENCY_PAIR;
+
+    public static MessageType getType(final String message) {
+        if (CurrencyUtils.isCurrencyRatePattern(message)) {
+            return CURRENCY_PAIR;
+        }
+        return TEXT;
+    }
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/usermessage/UserMessage.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/usermessage/UserMessage.java
@@ -15,8 +15,12 @@ public class UserMessage {
     private String userId;
     private String message;
 
-    public UserMessage(String userId, String message) {
+    @Enumerated(value = EnumType.STRING)
+    private MessageType messageType;
+
+    public UserMessage(String userId, String userMessage) {
         this.userId = userId;
-        this.message = message;
+        this.message = userMessage;
+        this.messageType = MessageType.getType(userMessage);
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/usermessage/UserMessageRepository.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/domain/usermessage/UserMessageRepository.java
@@ -6,4 +6,6 @@ import java.util.*;
 
 public interface UserMessageRepository extends JpaRepository<UserMessage, Long> {
     Optional<UserMessage> findFirstByUserIdOrderByIdDesc(String userId);
+
+    Optional<UserMessage> findFirstByUserIdAndMessageTypeOrderByIdDesc(String userId, MessageType messageType);
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/support/utils/CurrencyUtils.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/support/utils/CurrencyUtils.java
@@ -1,0 +1,30 @@
+package me.isooo.bot.support.utils;
+
+import me.isooo.bot.domain.currency.*;
+
+import java.time.*;
+import java.time.format.*;
+import java.util.regex.*;
+
+public class CurrencyUtils {
+    private static final Pattern CURRENCY_RATE_PATTERN = Pattern.compile("^([A-Z]{6})$");
+
+    public static boolean isCurrencyRatePattern(final String pattern) {
+        return CURRENCY_RATE_PATTERN.matcher(pattern).matches();
+    }
+
+    public static String currencyRateTextMessageFormatting(CurrencyRate currencyRate) {
+        return currencyRate.getBase()
+                + "/"
+                + currencyRate.getCounter()
+                + "의 환율 : "
+                + currencyRate.getRate()
+                + "\n\n"
+                + "※ 기준 시각\n"
+                + getDefaultFormalizedTimeMessage(currencyRate.getCreatedTime());
+    }
+
+    private static String getDefaultFormalizedTimeMessage(final LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+}

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/support/utils/CurrencyUtils.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/support/utils/CurrencyUtils.java
@@ -11,6 +11,7 @@ import java.util.*;
 import java.util.regex.*;
 
 public class CurrencyUtils {
+    private static final int DEFAULT_CURRENCY_UNIT = 1;
     private static final Pattern CURRENCY_RATE_PATTERN = Pattern.compile("^([A-Z]{6})$");
     private static final Pattern AMOUNT_PATTERN = Pattern.compile("^[0-9]+(?:[.][0-9]+)?$");
     private static final Pattern ALLOWABLE_AMOUNT_PATTERN = Pattern.compile("(^[0-9]{1,8}$)|(^[0-9]{1,6}[.][0-9]{1,2}$)");
@@ -27,15 +28,29 @@ public class CurrencyUtils {
     }
 
     public static String currencyRateTextMessageFormatting(CurrencyRate currencyRate) {
-        return currencyRate.getBase()
-                + "/"
-                + currencyRate.getCounter()
-                + "의 환율 : "
-                + currencyRate.getRate()
-                + "\n\n"
-                + "※ 기준 시각\n"
-                + getDefaultFormalizedTimeMessage(currencyRate.getCreatedTime());
+        final String formalizedRate = getFormalizedFigures(currencyRate.getRate());
+        return String.format("%d%s → %s%s입니다.\n\n※ 기준 시각\n%s",
+                DEFAULT_CURRENCY_UNIT,
+                currencyRate.getBaseUnit(),
+                formalizedRate,
+                currencyRate.getCounterUnit(),
+                getDefaultFormalizedTimeMessage(currencyRate.getCreatedTime())
+        );
     }
+
+    public static String amountResultTextMessageFormatting(String userMessage, CurrencyRate currencyRate) {
+        final String formalizedUserMessage = getFormalizedFigures(new BigDecimal(userMessage));
+        final String formalizedAmountResult = getFormalizedFigures(currencyRate.calculateAmount(new BigDecimal(userMessage)));
+        return String.format("%s%s → %s%s입니다.\n\n※ 기준 시각\n%s",
+                formalizedUserMessage,
+                currencyRate.getBaseUnit(),
+                formalizedAmountResult,
+                currencyRate.getCounterUnit(),
+                getDefaultFormalizedTimeMessage(currencyRate.getCreatedTime())
+        );
+    }
+
+
 
     private static String getDefaultFormalizedTimeMessage(final LocalDateTime localDateTime) {
         return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/support/utils/CurrencyUtils.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/support/utils/CurrencyUtils.java
@@ -1,16 +1,29 @@
 package me.isooo.bot.support.utils;
 
+import me.isooo.bot.domain.currency.Currency;
 import me.isooo.bot.domain.currency.*;
 
+import java.math.*;
+import java.text.*;
 import java.time.*;
 import java.time.format.*;
+import java.util.*;
 import java.util.regex.*;
 
 public class CurrencyUtils {
     private static final Pattern CURRENCY_RATE_PATTERN = Pattern.compile("^([A-Z]{6})$");
+    private static final Pattern AMOUNT_PATTERN = Pattern.compile("^[0-9]+(?:[.][0-9]+)?$");
+    private static final Pattern ALLOWABLE_AMOUNT_PATTERN = Pattern.compile("(^[0-9]{1,8}$)|(^[0-9]{1,6}[.][0-9]{1,2}$)");
+    private static final String DECIMAL_FORMAT_PATTERN = "###,##0.00";
+    private static final String BASE = "base";
+    private static final String COUNTER = "counter";
 
-    public static boolean isCurrencyRatePattern(final String pattern) {
-        return CURRENCY_RATE_PATTERN.matcher(pattern).matches();
+    public static boolean isCurrencyRatePattern(final String userMessage) {
+        return CURRENCY_RATE_PATTERN.matcher(userMessage).matches();
+    }
+
+    public static boolean isAmountPattern(String userMessage) {
+        return AMOUNT_PATTERN.matcher(userMessage).matches();
     }
 
     public static String currencyRateTextMessageFormatting(CurrencyRate currencyRate) {
@@ -26,5 +39,25 @@ public class CurrencyUtils {
 
     private static String getDefaultFormalizedTimeMessage(final LocalDateTime localDateTime) {
         return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    public static CurrencyRate convert(String text) {
+        final Map<String, Currency> currencyPair = extractCurrencyPair(text);
+        final Currency base = currencyPair.get(BASE);
+        final Currency counter = currencyPair.get(COUNTER);
+        return new CurrencyRate(base, counter);
+    }
+
+    private static Map<String, Currency> extractCurrencyPair(String text) {
+        final Map<String, Currency> map = new HashMap<>();
+        final Currency base = Currency.valueOf(text.substring(0, 3));
+        final Currency counter = Currency.valueOf(text.substring(3));
+        map.put(BASE, base);
+        map.put(COUNTER, counter);
+        return map;
+    }
+
+    public static String getFormalizedFigures(final BigDecimal figures) {
+        return new DecimalFormat(DECIMAL_FORMAT_PATTERN).format(figures);
     }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/test/java/me/isooo/bot/application/BotServiceTest.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/test/java/me/isooo/bot/application/BotServiceTest.java
@@ -66,7 +66,7 @@ class BotServiceTest {
         final String text = message.getText();
 
         // then
-        assertThat(text.split("\n")[0]).isEqualTo("KRW/USD의 환율 : 1000.1929");
+        assertThat(text.split("\n")[0]).isEqualTo("1원 → 1,000.19달러입니다.");
     }
 
     @DisplayName("제공되지 않는 통화 쌍이 입력되었을 때, 예외 메시지 테스트")
@@ -128,7 +128,7 @@ class BotServiceTest {
         final String text = message.getText();
 
         // then
-        assertThat(text).isEqualTo("1000원 → 1,000,192.90달러입니다.");
+        assertThat(text.split("\n")[0]).isEqualTo("1,000.00원 → 1,000,192.90달러입니다.");
     }
 
     @DisplayName("올바른 환율 조회 없이 금액 입력 시, 예외 메시지 테스트")

--- a/currency_rate_chatbot/currency-rate-bot/src/test/java/me/isooo/bot/application/BotServiceTest.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/test/java/me/isooo/bot/application/BotServiceTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.*;
 @SpringBootTest
 @Transactional
 class BotServiceTest {
+    private final String userId = "test001";
     @Autowired
     private UserMessageRepository userMessageRepository;
 
@@ -26,7 +27,6 @@ class BotServiceTest {
     @Test
     void helpGuideText() {
         // given
-        final String userId = "test001";
         final String userMessage = "help";
 
         // when
@@ -38,11 +38,10 @@ class BotServiceTest {
         assertThat(text).isEqualTo(GuideMenu.HELP_MESSAGE);
     }
 
-    @DisplayName("시작이 입력되었을 때, 기준 통화 목록이 응답되는지 테스트")
+    @DisplayName("시작이 입력되었을 때, 환율 입력에 대한 가이드가 응답되는지 테스트")
     @Test
-    void baseCurrencyGuideText() {
+    void currencyGuideText() {
         // given
-        final String userId = "test001";
         final String userMessage = "시작";
 
         // when
@@ -51,32 +50,15 @@ class BotServiceTest {
         final String text = message.getText();
 
         // then
-        assertThat(text.split("\n")[0]).isEqualTo("기준 통화 선택하기");
+        assertThat(text).isEqualTo("원하시는 환율에 대한 통화를 차례로 입력해주세요.\n" +
+                "e.g. 1유로(EUR) 대비 원화(KRW)가 궁금할 땐\n[EURKRW]를 입력하시면 됩니다 :)");
     }
 
-    @DisplayName("통화가 최초 입력되었을 때, 기준 통화로 인식하는 지 테스트")
+    @DisplayName("올바른 통화 쌍이 입력되었을 때, 환율이 제공되는지 테스트")
     @Test
-    void baseCurrencyHandle() {
+    void currencyRateInfoText() {
         // given
-        final String userId = "test001";
-        final String userMessage = "KRW";
-
-        // when
-        final List<Message> messages = service.handleTextContent(userId, userMessage);
-        final TextMessage message = (TextMessage) messages.get(0);
-        final String text = message.getText();
-
-        // then
-        assertThat(text.split("\n")[0]).isEqualTo("상대 통화 선택하기");
-    }
-
-    @DisplayName("통화가 입력되었을 때, 상대 통화로 인식하는 지 테스트")
-    @Test
-    void counterCurrencyHandle() {
-        // given
-        final String userId = "test001";
-        final String userMessage = "USD";
-        this.userMessageRepository.save(new UserMessage(userId, "KRW"));
+        final String userMessage = "KRWUSD";
 
         // when
         final List<Message> messages = service.handleTextContent(userId, userMessage);
@@ -87,13 +69,11 @@ class BotServiceTest {
         assertThat(text.split("\n")[0]).isEqualTo("KRW/USD의 환율 : 1000.1929");
     }
 
-    @DisplayName("제공되지 않는 통화 입력 시 예외 메시지 테스트")
+    @DisplayName("제공되지 않는 통화 쌍이 입력되었을 때, 예외 메시지 테스트")
     @Test
-    void unAllowableCurrencyHandle() {
+    void unallowableCurrencyRateGuideText() {
         // given
-        final String userId = "test001";
-        final String userMessage = "AAA";
-        this.userMessageRepository.save(new UserMessage(userId, "KRW"));
+        final String userMessage = "XXXYYY";
 
         // when
         final List<Message> messages = service.handleTextContent(userId, userMessage);
@@ -101,6 +81,70 @@ class BotServiceTest {
         final String text = message.getText();
 
         // then
-        assertThat(text).isEqualTo("통화를 다시 한 번 확인해주세요 :)");
+        assertThat(text).isEqualTo("가능한 통화 목록을 다시 확인해주세요 :)");
     }
+
+    @DisplayName("환전 금액 계산하기 입력 시, 금액 입력 가이드 제공 테스트")
+    @Test
+    void amountMenuGuideText() {
+        // given
+        final String userMessage = "환전 금액 계산하기";
+        this.userMessageRepository.save(new UserMessage(userId, "KRWUSD"));
+
+        // when
+        final List<Message> messages = service.handleTextContent(userId, userMessage);
+        final TextMessage message = (TextMessage) messages.get(0);
+        final String text = message.getText();
+
+        // then
+        assertThat(text).isEqualTo("환전할 금액(원)을 숫자로 입력해주세요.");
+    }
+
+    @DisplayName("환율 조회 없이 환전액 계산하기 입력 시, 예외 메시지 테스트")
+    @Test
+    void currencyRateEmptyGuideText() {
+        // given
+        final String userMessage = "환전 금액 계산하기";
+
+        // when
+        final List<Message> messages = service.handleTextContent(userId, userMessage);
+        final TextMessage message = (TextMessage) messages.get(0);
+        final String text = message.getText();
+
+        // then
+        assertThat(text).isEqualTo("환율 정보를 먼저 입력해주세요 :)");
+    }
+
+    @DisplayName("금액 입력 시, 환전액 제공 테스트")
+    @Test
+    void amountResultText() {
+        // given
+        final String userMessage = "1000";
+        this.userMessageRepository.save(new UserMessage(userId, "KRWUSD"));
+
+        // when
+        final List<Message> messages = service.handleTextContent(userId, userMessage);
+        final TextMessage message = (TextMessage) messages.get(0);
+        final String text = message.getText();
+
+        // then
+        assertThat(text).isEqualTo("1000원 → 1,000,192.90달러입니다.");
+    }
+
+    @DisplayName("올바른 환율 조회 없이 금액 입력 시, 예외 메시지 테스트")
+    @Test
+    void currencyRateEmptyGuideText2() {
+        // given
+        final String userMessage = "1000";
+        this.userMessageRepository.save(new UserMessage(userId, "XXXYYY"));
+
+        // when
+        final List<Message> messages = service.handleTextContent(userId, userMessage);
+        final TextMessage message = (TextMessage) messages.get(0);
+        final String text = message.getText();
+
+        // then
+        assertThat(text).isEqualTo("환율 정보를 먼저 입력해주세요 :)");
+    }
+
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/test/java/me/isooo/bot/application/BotServiceTest.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/test/java/me/isooo/bot/application/BotServiceTest.java
@@ -31,7 +31,7 @@ class BotServiceTest {
 
         // when
         final List<Message> messages = service.handleTextContent(userId, userMessage);
-        final TextMessage message = (TextMessage) messages.get(0);
+        final TextMessage message = (TextMessage) messages.get(1);
         final String text = message.getText();
 
         // then


### PR DESCRIPTION
- #21 PR에서 빠진 사항 추가 : 오탈자 입력 시, 스티커 메시지를 이용하여 가이드 로직에 대한 TC 추가 

- #7 수정된 요구 사항 반영
    - 기준 통화와 상대 통화를 동시에 입력 받음

- #22 제공되지 않는 통화쌍(Currency Pair) 입력 시, 안내 메시지와 함께 `시작` 메뉴 다시 제공

- #11 환산 금액 기능 추가
    - 환산 금액 메뉴 제공을 위한 `AmountMenu` 생성
    - `UserMessage`에 `MessageType`을 추가
        - 해당 유저의 입력 히스토리에 `MessageType`이 `CURRENCY_PAIR`가 있는지 확인
    - `CurrencyRate` 도메인 생성
    - 환산 금액 입력 시 처리할 `AmountResultMenu` 생성
        - 유저가 금액(숫자) 입력 시, 환전액 계산 기능은 `CurrencyRate` 도메인에서 수행

- #14 환산 금액 제공 후, `Quick Reply`를 이용하여 시작으로 돌아갈 수 있는 기능 추가

- 리펙토링
    - `CurrencyMenu` 메서드 분리
    - `CurrencyUtils` 생성  
        - `Currency`에서 필요한 기능 모음
            - e.g. CURRENCY_PAIR 패턴 체크 등
        - `XXXYYY`인 텍스트를 `CURRENCY_PAIR` 로 converting하는 기능을 `CurrencyUtils`로 extract함
        - #8 제공되는 환율의 포맷 지정
            - `DECIMAL_FORMAT_PATTERN = "###,##0.00"`

- #12 환산 금액 제공시, 해당 환율에 대한 업데이트 시간 표기
    - `CurrencyUtils.amountResultTextMessageFormatting()`에서 기능 수행

- #11 TC 추가
    - 기존 테스트 케이스 수정
    - 환전 금액 계산 기능에 대한 테스트 케이스 추가

- `log.error` 수정