### PR TITLE
feature/issue-13-amountFormat : 환산할 금액 입력 시, 포맷 한정

### DIFF
--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
@@ -33,6 +33,10 @@ public class AmountResultMenu implements Menu {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
         // TODO : #13 허용 가능한 포멧인지 체크 (CurrencyUtils.isAllowableAmountPattern())
 
+        if (!CurrencyUtils.isAllowableAmountPattern(userMessage)) {
+            return Collections.unmodifiableList(ExceptionMenu.unallowableAmountPattern(userId, userMessage));
+        }
+
         try {
             final UserMessage userCurrencyPair = userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(userId, MessageType.CURRENCY_PAIR).get();
             log.info("userCurrencyPair: {}", userCurrencyPair);

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
@@ -31,20 +31,17 @@ public class AmountResultMenu implements Menu {
     @Override
     public List<Message> getMessages(String userId, String userMessage) {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
-        // TODO : #13 허용 가능한 포멧인지 체크 (CurrencyUtils.isAllowableAmountPattern())
-
-        if (!CurrencyUtils.isAllowableAmountPattern(userMessage)) {
-            return Collections.unmodifiableList(ExceptionMenu.unallowableAmountPattern(userId, userMessage));
-        }
-
         try {
             final UserMessage userCurrencyPair = userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(userId, MessageType.CURRENCY_PAIR).get();
             log.info("userCurrencyPair: {}", userCurrencyPair);
             final String userCurrencyPairMessage = userCurrencyPair.getMessage();
+            if (!CurrencyUtils.isAllowableAmountPattern(userMessage)) {
+                return Collections.unmodifiableList(ExceptionMenu.unallowableAmountPattern(userId, userMessage));
+            }
             final CurrencyRate currencyRate = converter.convert(userCurrencyPairMessage);
             final TextMessage textMessage = getAmountResultMessage(userMessage, currencyRate);
             return Collections.singletonList(textMessage);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | NoSuchElementException e) {
             log.error("[IllegalArgumentException]", e);
             return Collections.unmodifiableList(ExceptionMenu.currencyPairEmpty(userId, userMessage));
         }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/AmountResultMenu.java
@@ -32,7 +32,8 @@ public class AmountResultMenu implements Menu {
     public List<Message> getMessages(String userId, String userMessage) {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
         try {
-            final UserMessage userCurrencyPair = userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(userId, MessageType.CURRENCY_PAIR).get();
+            final UserMessage userCurrencyPair = userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(userId, MessageType.CURRENCY_PAIR)
+                    .get();
             log.info("userCurrencyPair: {}", userCurrencyPair);
             final String userCurrencyPairMessage = userCurrencyPair.getMessage();
             if (!CurrencyUtils.isAllowableAmountPattern(userMessage)) {
@@ -42,7 +43,7 @@ public class AmountResultMenu implements Menu {
             final TextMessage textMessage = getAmountResultMessage(userMessage, currencyRate);
             return Collections.singletonList(textMessage);
         } catch (IllegalArgumentException | NoSuchElementException e) {
-            log.error("[IllegalArgumentException]", e);
+            log.error("[Exception]", e);
             return Collections.unmodifiableList(ExceptionMenu.currencyPairEmpty(userId, userMessage));
         }
     }

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/ExceptionMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/ExceptionMenu.java
@@ -11,6 +11,13 @@ import java.util.*;
 public class ExceptionMenu {
     private static final String UNALLOWABLE_CURRENCY_MESSAGE = "가능한 통화 목록을 다시 확인해주세요 :)";
     private static final String CURRENCY_PAIR_EMPTY_MESSAGE = "환율 정보를 먼저 입력해주세요 :)";
+    private static final String ALLOWABLE_AMOUNT_PATTERN_EXPLAIN = "※ 입력 가능한 금액 형식\n" +
+            "▶ 숫자는 총 8자리까지 가능하며,\n소수점 이하는 2자리까지 지원합니다.\n\n" +
+            "▶▶ 예시\n12345678(o)\n" +
+            "123456789(x)\n" +
+            "123456.78(o)\n" +
+            "1234567.89(x)\n" +
+            "123456.789(x)";
 
     public static List<Message> unallowableCurrency(String userId, String userMessage) {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
@@ -20,6 +27,11 @@ public class ExceptionMenu {
     public static List<Message> currencyPairEmpty(String userId, String userMessage) {
         log.info("userId: {}, userMessage: {}", userId, userMessage);
         return getMessages(userId, userMessage, CURRENCY_PAIR_EMPTY_MESSAGE);
+    }
+
+    public static List<Message> unallowableAmountPattern(String userId, String userMessage) {
+        log.info("userId: {}, userMessage: {}", userId, userMessage);
+        return getMessages(userId, userMessage, ALLOWABLE_AMOUNT_PATTERN_EXPLAIN);
     }
 
     private static List<Message> getMessages(String userId, String userMessage, String message) {

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/ExceptionMenu.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/application/menu/ExceptionMenu.java
@@ -20,21 +20,19 @@ public class ExceptionMenu {
             "123456.789(x)";
 
     public static List<Message> unallowableCurrency(String userId, String userMessage) {
-        log.info("userId: {}, userMessage: {}", userId, userMessage);
         return getMessages(userId, userMessage, UNALLOWABLE_CURRENCY_MESSAGE);
     }
 
     public static List<Message> currencyPairEmpty(String userId, String userMessage) {
-        log.info("userId: {}, userMessage: {}", userId, userMessage);
         return getMessages(userId, userMessage, CURRENCY_PAIR_EMPTY_MESSAGE);
     }
 
     public static List<Message> unallowableAmountPattern(String userId, String userMessage) {
-        log.info("userId: {}, userMessage: {}", userId, userMessage);
         return getMessages(userId, userMessage, ALLOWABLE_AMOUNT_PATTERN_EXPLAIN);
     }
 
     private static List<Message> getMessages(String userId, String userMessage, String message) {
+        log.info("userId: {}, userMessage: {}, ExceptionMessage: {}", userId, userMessage, message);
         final List<Message> messages = new ArrayList<>();
         final TextMessage textMessage = new TextMessage(message);
         messages.add(textMessage);

--- a/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/support/utils/CurrencyUtils.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/main/java/me/isooo/bot/support/utils/CurrencyUtils.java
@@ -65,4 +65,8 @@ public class CurrencyUtils {
     private static boolean isOutOfDate(LocalDateTime localDateTime) {
         return localDateTime.isBefore(LocalDateTime.now().minusDays(1));
     }
+
+    public static boolean isAllowableAmountPattern(final String pattern) {
+        return ALLOWABLE_AMOUNT_PATTERN.matcher(pattern).matches();
+    }
 }

--- a/currency_rate_chatbot/currency-rate-bot/src/test/java/me/isooo/bot/application/menu/AmountResultMenuTest.java
+++ b/currency_rate_chatbot/currency-rate-bot/src/test/java/me/isooo/bot/application/menu/AmountResultMenuTest.java
@@ -1,0 +1,120 @@
+package me.isooo.bot.application.menu;
+
+import com.linecorp.bot.model.message.*;
+import me.isooo.bot.application.*;
+import me.isooo.bot.domain.currency.Currency;
+import me.isooo.bot.domain.currency.*;
+import me.isooo.bot.domain.usermessage.*;
+import me.isooo.bot.support.utils.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import java.math.*;
+import java.text.*;
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("AmountResultMenu 테스트")
+@ExtendWith(MockitoExtension.class)
+class AmountResultMenuTest {
+    @Mock
+    private CurrencyRateConverter converter;
+
+    @Mock
+    private UserMessageRepository userMessageRepository;
+
+    @InjectMocks
+    private AmountResultMenu amountResultMenu;
+
+    private final String userId = "test001";
+
+    @DisplayName("유저가 통화를 입력하지 않은 상태에서 올바른 포맷의 금액을 입력했을 때, 통화 입력에 대한 가이드 테스트")
+    @Test
+    void currencyPairEmptyAndAllowableAmountPatternThenExceptionMenuTest() {
+        // given
+        final String userMessage = "1000";
+        when(userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(any(), any()))
+                .thenReturn(Optional.empty());
+
+        // when
+        final List<Message> messages = amountResultMenu.getMessages(userId, userMessage);
+        final TextMessage message = (TextMessage) messages.get(0);
+
+        // then
+        assertThat(message.getText()).isEqualTo("환율 정보를 먼저 입력해주세요 :)");
+    }
+
+    @DisplayName("유저가 유효하지 않은 통화를 입력하고 올바른 포맷의 금액을 입력했을 때, 통화 입력에 대한 가이드 테스트")
+    @Test
+    void unallowableCurrencyAndAllowableAmountPatternThenExceptionMenuTest() {
+        // given
+        final String userMessage = "1000";
+        final String userCurrencyPair = "XXXYYY";
+        when(userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(any(), any()))
+                .thenReturn(Optional.of(new UserMessage(userId, userCurrencyPair)));
+        when(converter.convert(userCurrencyPair))
+                .thenThrow(new IllegalArgumentException());
+
+        // when
+        final List<Message> messages = amountResultMenu.getMessages(userId, userMessage);
+        final TextMessage message = (TextMessage) messages.get(0);
+
+        // then
+        assertThat(message.getText()).isEqualTo("환율 정보를 먼저 입력해주세요 :)");
+    }
+
+    @DisplayName("유효한 통화 정보가 존재하고 올바른 포맷의 금액을 입력했을 때, 환산액 가이드 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = {"12345678", "123456.12", "1", "100"})
+    void allowableCurrencyAndAllowableAmountPatternThenSuccess(String userMessage) {
+        // given
+        final String userCurrencyPair = "USDEUR";
+        final LocalDateTime now = LocalDateTime.now();
+        final BigDecimal rate = new BigDecimal("1.123456");
+        when(userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(any(), any()))
+                .thenReturn(Optional.of(new UserMessage(userId, userCurrencyPair)));
+        when(converter.convert(any()))
+                .thenReturn(new CurrencyRate(Currency.USD, Currency.EUR, rate, now));
+
+        // when
+        final List<Message> messages = amountResultMenu.getMessages(userId, userMessage);
+        final TextMessage message = (TextMessage) messages.get(0);
+
+        // then
+        assertThat(message.getText())
+                .isEqualTo(
+                        new DecimalFormat("###,##0.00").format(new BigDecimal(userMessage)) +
+                                "달러 → " +
+                                new DecimalFormat("###,##0.00").format(new BigDecimal(userMessage).multiply(rate)) +
+                                "유로입니다.\n\n" +
+                                CurrencyUtils.getFormalizedTimeMessageMessage(now)
+                );
+    }
+
+    @DisplayName("유효한 통화 정보가 존재하고 올바르지 않은 포맷의 금액을 입력했을 때, 금액 입력 가이드 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = {"123456789", "123456.123"})
+    void allowableCurrencyAndUnallowableAmountPatternThenExceptionMenuTest(String userMessage) {
+        // given
+        final String userCurrencyPair = "USDEUR";
+        final LocalDateTime now = LocalDateTime.now();
+        when(userMessageRepository.findFirstByUserIdAndMessageTypeOrderByIdDesc(any(), any()))
+                .thenReturn(Optional.of(new UserMessage(userId, userCurrencyPair)));
+
+        // when
+        final List<Message> messages = amountResultMenu.getMessages(userId, userMessage);
+        final TextMessage message = (TextMessage) messages.get(0);
+
+        // then
+        assertThat(message.getText().split("\n")[0])
+                .isEqualTo("※ 입력 가능한 금액 형식");
+    }
+}


### PR DESCRIPTION
- #13 환산할 금액 입력 시, 포맷 한정 
    - 입력받는 금액이 자연수일 경우 10자리까지, 유리수일 경우 정수부 8자리 그리고 소수부 2자리까지로 한정 
    - 유저가 입력한 통화가 존재하는지 체크하고 > 그 이후 입력한 금액에 대한 유효성 체크 
- 예외 상황 정리
    - #22 제공되지 않는 통화가 `CURRENCY_PAIR` 타입으로 `UserMessageRepository`에서 find되었을 때, `Currency.valueOf()`에서 `IllegalArgumentException` 발생 
    - #22 유저가 입력한 환율이 존재하지 않을 경우, `UserMessageRepository`에서 꺼내온 값은 `Optional.Empty`이기 때문에 이때 `get()`할 경우 `NoSuchElementException` 발생 
- #13 테스트케이스 작성